### PR TITLE
Add Terraform scripts to deploy infrastructure. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+tf/.terraform/*
+*.tfstate
+*.tfstate.*
+tf/.terraform.lock.hcl

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -23,6 +23,7 @@ provider "aws" {
 
 module "acm_request_certificate" {
   source = "cloudposse/acm-request-certificate/aws"
+  # Documentation: https://github.com/cloudposse/terraform-aws-acm-request-certificate/blob/master/README.md
   providers = {
     aws = aws.us
   }
@@ -37,6 +38,7 @@ module "acm_request_certificate" {
 
 module "cdn" {
   source = "cloudposse/cloudfront-s3-cdn/aws"
+  # Documentation: https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/blob/master/README.md
   # Cloud Posse recommends pinning every module to a specific version
   version = "0.74.3"
 

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = ">= 0.14.9"
+  required_version = "1.0.5"
 }
 
 provider "aws" {

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -53,6 +53,9 @@ module "cdn" {
     (var.deployment_user) = [""]
   }
 
+  # There seems to be a weird issue here where if the acm has not been run by itself, you will
+  # get some weird errors here regarding the zone_id. To fix these comment the below two lines
+  # out and run terraform apply, then uncomment them and run apply again.
   depends_on          = [module.acm_request_certificate]
   acm_certificate_arn = module.acm_request_certificate.arn
 

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -1,0 +1,18 @@
+variable "root_url" {
+  type        = string
+  description = "The root url for the website."
+  default     = "neurowinter.dev"
+}
+
+variable "subdomains" {
+  type        = list(any)
+  description = "The list of subdomains that you want the site to be deployed to."
+  # I wanted to use the root url here, but terraform does not like nested variables.
+  default = ["www.neurowinter.dev"]
+}
+
+variable "deployment_user" {
+  type        = string
+  description = "The user that you want to deploy the infrastructure."
+  default     = "arn:aws:iam::058786660650:user/personal_deployment"
+}


### PR DESCRIPTION
This PR aims to set up all the Terraform scripts to set up the infrastructure to host the site on AWS.

This includes:
* Creating an ACM cert for the site, meaning that it is HTTPS
* Creating a CDN to host the site.
* Creating all the S3 buckets that are required for a static site.